### PR TITLE
Implement initial Windows disk access modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+/build/
+/out/
+/.vs/
+*.user
+*.vcxproj*
+CMakeCache.txt
+CMakeFiles/
+*.obj
+*.pdb
+*.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.16)
+project(DataRecoveryTool LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(drt_core
+    src/DiskEnumerator.cpp
+    src/RawDiskReader.cpp
+    src/NtfsStructures.cpp
+)
+
+target_include_directories(drt_core PUBLIC include)
+
+add_executable(DataRecoveryTool src/main.cpp)
+target_link_libraries(DataRecoveryTool PRIVATE drt_core)
+
+if (MSVC)
+    target_compile_definitions(drt_core PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RecorveryDataTool
-Phase 0 – Chuẩn bị & định hướng
+## Phase 0 – Chuẩn bị & định hướng
 
  Xác định phạm vi tool
 
@@ -39,9 +39,9 @@ Phase 0 – Chuẩn bị & định hướng
 
  Cấu trúc cơ bản NTFS (Boot Sector, MFT, $Bitmap, Attribute…)
 
-Phase 1 – Truy cập raw disk (đọc ổ đĩa ở mức thấp)
+## Phase 1 – Truy cập raw disk (đọc ổ đĩa ở mức thấp)
 
- Task 1: Liệt kê các volume/partition có trên hệ thống
+### Task 1: Liệt kê các volume/partition có trên hệ thống ✅
 
  Viết module DiskEnumerator:
 
@@ -49,7 +49,7 @@ Phase 1 – Truy cập raw disk (đọc ổ đĩa ở mức thấp)
 
  In danh sách: C:, D:, E:… + loại (Fixed/Removable) + filesystem (NTFS/FAT32…)
 
- Task 2: Mở volume ở chế độ raw
+### Task 2: Mở volume ở chế độ raw ✅
 
  Viết module RawDiskReader:
 
@@ -64,9 +64,9 @@ bool ReadSectors(HANDLE hVolume, uint64_t startSector, uint32_t sectorCount, std
 
  Test: đọc Boot Sector (sector 0 của partition) và in ra một vài byte đầu để kiểm tra.
 
-Phase 2 – Parser hệ file NTFS (đọc cấu trúc logic)
+## Phase 2 – Parser hệ file NTFS (đọc cấu trúc logic)
 
- Task 3: Đọc & phân tích NTFS Boot Sector
+### Task 3: Đọc & phân tích NTFS Boot Sector ✅
 
  Tạo struct C++ map với NTFS Boot Sector (BPB)
 
@@ -213,7 +213,7 @@ enum class RecoveryStatus {
 
  Giai đoạn sau, khi core NTFS đã ổn.
 
-Phase 5 – Giao diện dòng lệnh (CLI)
+## Phase 5 – Giao diện dòng lệnh (CLI)
 
  Task 11: Xây menu console
 
@@ -233,7 +233,7 @@ Thoát
 
  In log đơn giản ra console (bước đầu chưa cần logging phức tạp)
 
-Phase 6 – Giao diện GUI (kết hợp với console)
+## Phase 6 – Giao diện GUI (kết hợp với console)
 
  Task 12: Chọn framework GUI
 
@@ -267,7 +267,7 @@ Không phụ thuộc vào console hay GUI
 
  UI (console/GUI) chỉ gọi hàm từ các module này → dễ bảo trì, test.
 
-Phase 7 – Logging, an toàn, tài liệu
+## Phase 7 – Logging, an toàn, tài liệu
 
  Task 14: Thêm hệ thống logging
 
@@ -300,3 +300,12 @@ Phase 7 – Logging, an toàn, tài liệu
  Không đảm bảo 100% khôi phục
 
  File bị ghi đè thì không cứu được
+
+## Xây dựng & chạy thử
+
+```
+cmake -S . -B build
+cmake --build build
+```
+
+> ⚠️ Ứng dụng hiện chỉ chạy được trên Windows vì phụ thuộc Windows API.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,19 @@
+# DataRecoveryTool – Kiến trúc giai đoạn đầu
+
+Tài liệu này ghi lại những thành phần đã được triển khai theo kế hoạch trong README.
+
+## Module `DiskEnumerator`
+* Chịu trách nhiệm liệt kê các volume có trên hệ thống Windows bằng Windows API.
+* Xuất danh sách `DiskInfo` gồm ký tự ổ đĩa, loại ổ và filesystem.
+
+## Module `RawDiskReader`
+* Cung cấp API đọc sector ở chế độ raw từ một volume.
+* Hiện tại giới hạn trên Windows, đọc theo block 512 byte.
+
+## Module `NtfsStructures`
+* Parse NTFS Boot Sector từ buffer 512 byte.
+* Trả về các thông tin quan trọng để định vị MFT trong những giai đoạn kế tiếp.
+
+## Ứng dụng console
+* Menu đơn giản cho phép người dùng chọn volume và đọc Boot Sector.
+* Dùng wide string để hiển thị tiếng Việt chính xác.

--- a/include/DiskEnumerator.h
+++ b/include/DiskEnumerator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace drt {
+
+struct DiskInfo {
+    std::wstring rootPath;
+    std::wstring driveType;
+    std::wstring fileSystem;
+};
+
+std::vector<DiskInfo> EnumerateVolumes();
+
+} // namespace drt

--- a/include/NtfsStructures.h
+++ b/include/NtfsStructures.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drt {
+
+struct NtfsBootSector {
+    std::string oemId;
+    std::uint16_t bytesPerSector = 0;
+    std::uint8_t sectorsPerCluster = 0;
+    std::uint16_t reservedSectors = 0;
+    std::uint64_t totalSectors = 0;
+    std::uint64_t mftCluster = 0;
+    std::uint64_t mftMirrorCluster = 0;
+    std::int8_t clustersPerFileRecord = 0;
+    std::int8_t clustersPerIndexRecord = 0;
+};
+
+bool parseNtfsBootSector(const std::vector<std::uint8_t> &buffer, NtfsBootSector &out);
+
+} // namespace drt

--- a/include/RawDiskReader.h
+++ b/include/RawDiskReader.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drt {
+
+class RawDiskReader {
+public:
+    RawDiskReader();
+    ~RawDiskReader();
+
+    bool open(const std::wstring &volumePath);
+    void close();
+    bool readSectors(std::uint64_t startSector, std::uint32_t sectorCount, std::vector<std::uint8_t> &buffer) const;
+    bool isOpen() const noexcept;
+
+private:
+#ifdef _WIN32
+    void *m_handle;
+#endif
+};
+
+} // namespace drt

--- a/src/DiskEnumerator.cpp
+++ b/src/DiskEnumerator.cpp
@@ -1,0 +1,73 @@
+#include "DiskEnumerator.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+#include <stdexcept>
+#include <cwchar>
+
+namespace drt {
+
+namespace {
+
+#ifdef _WIN32
+std::wstring driveTypeToString(UINT type) {
+    switch (type) {
+    case DRIVE_UNKNOWN:
+        return L"Unknown";
+    case DRIVE_NO_ROOT_DIR:
+        return L"Invalid";
+    case DRIVE_REMOVABLE:
+        return L"Removable";
+    case DRIVE_FIXED:
+        return L"Fixed";
+    case DRIVE_REMOTE:
+        return L"Network";
+    case DRIVE_CDROM:
+        return L"CD/DVD";
+    case DRIVE_RAMDISK:
+        return L"RAM Disk";
+    default:
+        return L"Other";
+    }
+}
+#endif
+
+} // namespace
+
+std::vector<DiskInfo> EnumerateVolumes() {
+    std::vector<DiskInfo> result;
+
+#ifdef _WIN32
+    DWORD length = GetLogicalDriveStringsW(0, nullptr);
+    if (length == 0) {
+        return result;
+    }
+
+    std::wstring buffer(length, L'\0');
+    DWORD written = GetLogicalDriveStringsW(length, buffer.data());
+    if (written == 0) {
+        return result;
+    }
+
+    for (wchar_t *drive = buffer.data(); *drive != L'\0'; drive += wcslen(drive) + 1) {
+        DiskInfo info{};
+        info.rootPath = drive;
+        info.driveType = driveTypeToString(GetDriveTypeW(drive));
+
+        wchar_t fsNameBuffer[MAX_PATH] = {0};
+        if (GetVolumeInformationW(drive, nullptr, 0, nullptr, nullptr, nullptr, fsNameBuffer, MAX_PATH)) {
+            info.fileSystem = fsNameBuffer;
+        }
+
+        result.push_back(std::move(info));
+    }
+#else
+    throw std::runtime_error("Volume enumeration is only supported on Windows.");
+#endif
+
+    return result;
+}
+
+} // namespace drt

--- a/src/NtfsStructures.cpp
+++ b/src/NtfsStructures.cpp
@@ -1,0 +1,51 @@
+#include "NtfsStructures.h"
+
+#include <array>
+#include <cstring>
+
+namespace drt {
+
+namespace {
+constexpr std::size_t kBootSectorSize = 512;
+
+std::uint64_t readLE64(const std::uint8_t *data) {
+    std::uint64_t value = 0;
+    for (int i = 7; i >= 0; --i) {
+        value = (value << 8) | data[i];
+    }
+    return value;
+}
+
+std::uint32_t readLE32(const std::uint8_t *data) {
+    std::uint32_t value = 0;
+    for (int i = 3; i >= 0; --i) {
+        value = (value << 8) | data[i];
+    }
+    return value;
+}
+
+std::uint16_t readLE16(const std::uint8_t *data) {
+    return static_cast<std::uint16_t>(data[0] | (data[1] << 8));
+}
+
+} // namespace
+
+bool parseNtfsBootSector(const std::vector<std::uint8_t> &buffer, NtfsBootSector &out) {
+    if (buffer.size() < kBootSectorSize) {
+        return false;
+    }
+
+    out.oemId.assign(reinterpret_cast<const char *>(&buffer[3]), 8);
+    out.bytesPerSector = readLE16(&buffer[11]);
+    out.sectorsPerCluster = buffer[13];
+    out.reservedSectors = readLE16(&buffer[14]);
+    out.totalSectors = readLE64(&buffer[40]);
+    out.mftCluster = readLE64(&buffer[48]);
+    out.mftMirrorCluster = readLE64(&buffer[56]);
+    out.clustersPerFileRecord = static_cast<std::int8_t>(buffer[64]);
+    out.clustersPerIndexRecord = static_cast<std::int8_t>(buffer[68]);
+
+    return out.oemId.find("NTFS") != std::string::npos;
+}
+
+} // namespace drt

--- a/src/RawDiskReader.cpp
+++ b/src/RawDiskReader.cpp
@@ -1,0 +1,79 @@
+#include "RawDiskReader.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+#include <stdexcept>
+
+namespace drt {
+
+RawDiskReader::RawDiskReader()
+#ifdef _WIN32
+    : m_handle(INVALID_HANDLE_VALUE)
+#endif
+{
+}
+
+RawDiskReader::~RawDiskReader() { close(); }
+
+bool RawDiskReader::open(const std::wstring &volumePath) {
+#ifdef _WIN32
+    close();
+    m_handle = CreateFileW(volumePath.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    return m_handle != INVALID_HANDLE_VALUE;
+#else
+    (void)volumePath;
+    throw std::runtime_error("Raw disk reading is only supported on Windows.");
+#endif
+}
+
+void RawDiskReader::close() {
+#ifdef _WIN32
+    if (m_handle != nullptr && m_handle != INVALID_HANDLE_VALUE) {
+        CloseHandle(static_cast<HANDLE>(m_handle));
+        m_handle = INVALID_HANDLE_VALUE;
+    }
+#endif
+}
+
+bool RawDiskReader::readSectors(std::uint64_t startSector, std::uint32_t sectorCount, std::vector<std::uint8_t> &buffer) const {
+#ifdef _WIN32
+    if (m_handle == nullptr || m_handle == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    LARGE_INTEGER position;
+    position.QuadPart = static_cast<LONGLONG>(startSector) * 512ULL; // default sector size assumption
+    if (!SetFilePointerEx(static_cast<HANDLE>(m_handle), position, nullptr, FILE_BEGIN)) {
+        return false;
+    }
+
+    DWORD bytesToRead = sectorCount * 512U;
+    buffer.resize(bytesToRead);
+
+    DWORD bytesRead = 0;
+    if (!ReadFile(static_cast<HANDLE>(m_handle), buffer.data(), bytesToRead, &bytesRead, nullptr)) {
+        buffer.clear();
+        return false;
+    }
+
+    buffer.resize(bytesRead);
+    return bytesRead == bytesToRead;
+#else
+    (void)startSector;
+    (void)sectorCount;
+    (void)buffer;
+    throw std::runtime_error("Raw disk reading is only supported on Windows.");
+#endif
+}
+
+bool RawDiskReader::isOpen() const noexcept {
+#ifdef _WIN32
+    return m_handle != nullptr && m_handle != INVALID_HANDLE_VALUE;
+#else
+    return false;
+#endif
+}
+
+} // namespace drt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,88 @@
+#include "DiskEnumerator.h"
+#include "NtfsStructures.h"
+#include "RawDiskReader.h"
+
+#include <iostream>
+#include <locale>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+namespace {
+
+void printVolumes(const std::vector<drt::DiskInfo> &volumes) {
+    std::wcout << L"\nDanh sách volume phát hiện:\n";
+    for (std::size_t i = 0; i < volumes.size(); ++i) {
+        const auto &vol = volumes[i];
+        std::wcout << i + 1 << L". " << vol.rootPath << L" (" << vol.driveType << L", " << vol.fileSystem << L")\n";
+    }
+}
+
+void printBootInfo(const drt::NtfsBootSector &boot) {
+    std::wcout << L"\nThông tin NTFS Boot Sector:\n";
+    std::wcout << L"OEM ID: " << std::wstring(boot.oemId.begin(), boot.oemId.end()) << L"\n";
+    std::wcout << L"Bytes/Sector: " << boot.bytesPerSector << L"\n";
+    std::wcout << L"Sectors/Cluster: " << static_cast<int>(boot.sectorsPerCluster) << L"\n";
+    std::wcout << L"Cluster MFT: " << boot.mftCluster << L"\n";
+    std::wcout << L"Cluster MFT Mirror: " << boot.mftMirrorCluster << L"\n";
+}
+
+} // namespace
+
+int wmain() {
+#ifndef _WIN32
+    std::cerr << "DataRecoveryTool hiện chỉ chạy trên Windows." << std::endl;
+    return 1;
+#else
+    std::locale::global(std::locale(""));
+    std::wcout.imbue(std::locale());
+
+    auto volumes = drt::EnumerateVolumes();
+    if (volumes.empty()) {
+        std::wcerr << L"Không tìm thấy volume nào." << std::endl;
+        return 1;
+    }
+
+    printVolumes(volumes);
+
+    std::wcout << L"\nChọn volume để đọc Boot Sector (nhập số, 0 để thoát): ";
+    std::size_t selection = 0;
+    std::wcin >> selection;
+    if (!std::wcin || selection == 0 || selection > volumes.size()) {
+        std::wcerr << L"Lựa chọn không hợp lệ." << std::endl;
+        return 1;
+    }
+
+    const auto &chosen = volumes[selection - 1];
+    std::wstring volumePath = L"\\\\.\\" + chosen.rootPath.substr(0, 2);
+
+    drt::RawDiskReader reader;
+    if (!reader.open(volumePath)) {
+        std::wcerr << L"Không mở được volume." << std::endl;
+        return 1;
+    }
+
+    std::vector<std::uint8_t> buffer;
+    if (!reader.readSectors(0, 1, buffer)) {
+        std::wcerr << L"Đọc boot sector thất bại." << std::endl;
+        return 1;
+    }
+
+    drt::NtfsBootSector boot{};
+    if (!drt::parseNtfsBootSector(buffer, boot)) {
+        std::wcerr << L"Volume không phải NTFS hoặc boot sector không hợp lệ." << std::endl;
+        return 1;
+    }
+
+    printBootInfo(boot);
+    return 0;
+#endif
+}
+
+#ifndef _WIN32
+int main() { return wmain(); }
+#endif

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Các test tự động sẽ được bổ sung khi core NTFS parser hoàn thiện hơn. Hiện tại code phụ thuộc Windows API nên chưa thể chạy unit test trong môi trường Linux.


### PR DESCRIPTION
## Summary
- add CMake-based C++ project structure with core headers and sources for disk enumeration, raw reading, and NTFS boot parsing
- implement a Windows-only console workflow to list volumes, open a raw handle, and parse the boot sector
- document the module layout, current progress, and basic build steps

## Testing
- not run (Windows-specific code)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b3f29364833392df80266d80a803)